### PR TITLE
Fix - fail with special characters in paths - be quotted

### DIFF
--- a/pymtt/filters/plist.py
+++ b/pymtt/filters/plist.py
@@ -8,8 +8,9 @@ import os
 import yaml
 
 
-PLIST_CMD = "/usr/ports/Tools/scripts/plist" 
-PLIST_BSD_LOCAL = "/usr/ports/Templates/BSD.local.dist" 
+DIR = os.path.dirname(os.path.abspath(__file__))
+PLIST_CMD = os.path.join(DIR, "plist")
+PLIST_BSD_LOCAL = os.path.join(DIR, "BSD.local.dist")
 
 
 def makeplist(root, prefix='/usr/local', user=None, group=None):
@@ -63,4 +64,4 @@ def gen_manifest(root, prefix, user, group):
 		meta = get_stat(path, user, group)
 		meta['sum'] = h.hexdigest() if not os.path.islink(path) else "-"
 		data['files'][os.path.join(prefix, _file)] = meta
-	return yaml.dump(data)
+	return yaml.safe_dump(data, default_style='"', default_flow_style=True)[1:-1]


### PR DESCRIPTION
Standard FreeBSD pkg utility fail if in generated MANIFEST has file with special characters (for example '+') in abspath. This patch enable quotting in generated manifest.
And fix trouble - if system ports is not installed.